### PR TITLE
Add booked transfer constraints

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,8 @@ You will need to follow steps below to install required platform and also optimi
         "locked": [],
         "delete_tmp": true,
         "secs": 300,
-        "use_cmd": false
+        "use_cmd": false,
+        "booked_transfers": []
     }
   ```
 
@@ -114,6 +115,7 @@ You will need to follow steps below to install required platform and also optimi
   - `delete_tmp`: `true` or `false` whether to delete generated temporary files after solve
   - `secs`: time limit for the solve (in seconds)
   - `use_cmd`: whether to use `os.system` or `subprocess` for running solver, default is `false`
+  - `booked_transfers`: list of booked transfers for future gameweeks. needs to have a `gw` key and at least one of `transfer_in` or `transfer_out` with the player ID  (e.g. `233` for Salah)
 
 - Run the multi-period optimization
   

--- a/run/regular_settings.json
+++ b/run/regular_settings.json
@@ -14,5 +14,6 @@
     "use_wc": null,
     "use_bb": null,
     "use_fh": null,
-    "chip_limits": {"bb": 0, "wc": 0, "fh": 0, "tc": 0}
+    "chip_limits": {"bb": 0, "wc": 0, "fh": 0, "tc": 0},
+    "booked_transfers": []
 }


### PR DESCRIPTION
This PR adds booked transfer constraints in case a person wants to buy or sell a specific player in a given game week.

As an example, you can have this in the `regular_settings.json` file:

```json
"booked_transfers": [
    {
      "gw": 33,
      "transfer_in": 579
    },
    {
      "gw": 32,
      "transfer_in": 591
    },
    {
      "gw": 34,
      "transfer_out": 233
    }
]
```

Which means you are forcing the optimizer to buy Rondon in GW32 and Ronaldo in GW33 and sell Salah in GW34.