### PR TITLE
multi_sell_2 constraint fix

### DIFF
--- a/src/multi_period_dev.py
+++ b/src/multi_period_dev.py
@@ -386,7 +386,7 @@ def solve_multi_period_fpl(data, options):
     ## Multiple-sell fix
     model.add_constraints((transfer_out_first[p,w] + transfer_out_regular[p,w] <= 1 for p in price_modified_players for w in gameweeks), name='multi_sell_1')
     model.add_constraints((
-        (wbar - next_gw + 1) * so.expr_sum(transfer_out_first[p,w] for w in gameweeks if w >= wbar) >=
+        horizon * so.expr_sum(transfer_out_first[p,w] for w in gameweeks if w <= wbar) >=
         so.expr_sum(transfer_out_regular[p,w] for w in gameweeks if w >= wbar)
         for p in price_modified_players for wbar in gameweeks
     ), name='multi_sell_2')


### PR DESCRIPTION
Added the changes suggested by @sertalpbilal for the multi_sell_2 constraint. Two changes: 
Replace `wbar-next_gw+1` with `horizon` and replace `w >= wbar` in first sum with `w <= wbar`.