### PR TITLE
Maximum defenders per team option

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ You will need to follow steps below to install required platform and also optimi
         "no_opposing_play": false,
         "pick_prices": {"G": "", "D": "", "M": "", "F": ""},
         "no_gk_rotation_after": null,
+        "max_defenders_per_team": 3,
         "iteration": 1,
         "iteration_criteria": "this_gw_transfer_in",
         "iteration_target": [],
@@ -198,6 +199,7 @@ You will need to follow steps below to install required platform and also optimi
     For example, to force two 11.5M forwards, and one 8M midfielder, use
     `"pick_prices": {"G": "", "D": "", "M": "8", "F": "11.5,11.5"}`
   - `no_gk_rotation_after`: use same lineup GK after given GW, e.g. setting this value to `26` means all GWs after 26 will use same lineup GK
+  - `max_defenders_per_team`: the maximum number of defenders and goalkeepers from one team in your squad, defaults to 3
   - `iteration`: number of different solutions to be generated, the criteria is controlled by `iteration_criteria`
   - `iteration_criteria`: rule on separating what a different solution mean  
     - `this_gw_transfer_in` will force to replace players to buy current GW in each solution

--- a/data/regular_settings.json
+++ b/data/regular_settings.json
@@ -49,6 +49,7 @@
     "opposing_play_group": "position",
     "pick_prices": {"G": "", "D": "", "M": "", "F": ""},
     "no_gk_rotation_after": null,
+    "max_defenders_per_team": 3,
     "iteration": 1,
     "iteration_criteria": "this_gw_transfer_in",
     "iteration_difference": 1,

--- a/src/multi_period_dev.py
+++ b/src/multi_period_dev.py
@@ -615,7 +615,12 @@ def solve_multi_period_fpl(data, options):
     if options.get("no_transfer_gws", None) is not None:
         if len(options['no_transfer_gws']) > 0:
             model.add_constraint(so.expr_sum(transfer_in[p,w] for p in players for w in options['no_transfer_gws']) == 0, name='banned_gws_for_tr')
-    
+
+    max_defs_per_team = options.get("max_defenders_per_team", 3)
+    if max_defs_per_team < 3:   # only add constraints if necessary
+        model.add_constraints((so.expr_sum(squad[p,w] for p in players if merged_data.loc[p, 'name'] == t and merged_data.loc[p, 'Pos'] in {'G', 'D'}) <= max_defs_per_team for t in teams for w in gameweeks), name='defenders_per_team_limit')
+        model.add_constraints((so.expr_sum(squad_fh[p,w] for p in players if merged_data.loc[p, 'name'] == t and merged_data.loc[p, 'Pos'] in {'G', 'D'}) <= max_defs_per_team * use_fh[w] for t in teams for w in gameweeks), name='defenders_per_team_limit_fh')
+
     for booked_transfer in booked_transfers:
         transfer_gw = booked_transfer.get('gw', None)
 


### PR DESCRIPTION
Cos sometimes you want to spread your clean sheet eggs across multiple baskets.

Adds an optional constraint to the solver to limit the defenders per team in your squad.