### PR TITLE
Fix duplicated entries in sensitivity analysis

### DIFF
--- a/run/sensitivity.py
+++ b/run/sensitivity.py
@@ -26,6 +26,7 @@ def read_sensitivity(options=None):
 
         for filename in Path(directory).glob("*.csv"):
             plan = pd.read_csv(filename)
+            plan = plan.sort_values(by=["week", "iter", "pos", "id"])
             try:
                 iter = plan.iloc[0]['iter']
             except:


### PR DESCRIPTION
When a transfer plan included transferring in multiple players, sensitivity analysis would consider a reordering of those same players as a different transfer plan.