### PR TITLE
Add ITB, FT, PT, NT to team visualization

### DIFF
--- a/data/regular_settings.json
+++ b/data/regular_settings.json
@@ -1,5 +1,5 @@
 {
-    "horizon": 5,
+    "horizon": 3,
     "decay_base": 0.84,
     "ft_value": 1.5,
     "ft_value_list": {},
@@ -33,9 +33,9 @@
     "use_bb": null,
     "use_fh": null,
     "use_tc": null,
-    "chip_limits": {"bb": 0, "wc": 0, "fh": 0, "tc": 0},
+    "chip_limits": {"bb": 0, "wc": 1, "fh": 0, "tc": 0},
     "no_chip_gws": [],
-    "allowed_chip_gws": {"bb": [], "wc": [], "fh": [], "tc": []},
+    "allowed_chip_gws": {"bb": [], "wc": [13], "fh": [], "tc": []},
     "forced_chip_gws": {"bb": [], "wc": [], "fh": [], "tc": []},
     "run_chip_combinations": {"bb": [], "wc": [], "fh": [], "tc": []},
     "future_transfer_limit": null,
@@ -46,7 +46,7 @@
     "ft_custom_value": {},
     "preseason": false,
     "use_login": false,
-    "solver": "cbc",
+    "solver": "highs",
     "solver_path": null,
     "no_opposing_play": false,
     "opposing_play_group": "position",
@@ -63,8 +63,8 @@
     "datasource" : "review",
     "data_weights": {"review": 40, "review-odds": 30, "mikkel": 30, "kiwi": 0},
     "export_data": "final.csv",
-    "team_data": "json",
-    "team_id": null,
+    "team_data": "ID",
+    "team_id": 15258,
     "export_image": true,
     "solve_name": "regular"
 }

--- a/data/regular_settings.json
+++ b/data/regular_settings.json
@@ -1,5 +1,5 @@
 {
-    "horizon": 3,
+    "horizon": 5,
     "decay_base": 0.84,
     "ft_value": 1.5,
     "ft_value_list": {},
@@ -33,9 +33,9 @@
     "use_bb": null,
     "use_fh": null,
     "use_tc": null,
-    "chip_limits": {"bb": 0, "wc": 1, "fh": 0, "tc": 0},
+    "chip_limits": {"bb": 0, "wc": 0, "fh": 0, "tc": 0},
     "no_chip_gws": [],
-    "allowed_chip_gws": {"bb": [], "wc": [13], "fh": [], "tc": []},
+    "allowed_chip_gws": {"bb": [], "wc": [], "fh": [], "tc": []},
     "forced_chip_gws": {"bb": [], "wc": [], "fh": [], "tc": []},
     "run_chip_combinations": {"bb": [], "wc": [], "fh": [], "tc": []},
     "future_transfer_limit": null,
@@ -46,7 +46,7 @@
     "ft_custom_value": {},
     "preseason": false,
     "use_login": false,
-    "solver": "highs",
+    "solver": "cbc",
     "solver_path": null,
     "no_opposing_play": false,
     "opposing_play_group": "position",
@@ -63,8 +63,8 @@
     "datasource" : "review",
     "data_weights": {"review": 40, "review-odds": 30, "mikkel": 30, "kiwi": 0},
     "export_data": "final.csv",
-    "team_data": "ID",
-    "team_id": 15258,
+    "team_data": "json",
+    "team_id": null,
     "export_image": true,
     "solve_name": "regular"
 }

--- a/run/solve_regular.py
+++ b/run/solve_regular.py
@@ -97,6 +97,7 @@ def solve_regular(runtime_options=None):
         if options.get('export_image', 0) and not is_colab:
             create_squad_timeline(
                 current_squad=data['initial_squad'],
+                statistics=result['statistics'],
                 picks=result['picks'],
                 filename=filename
             )

--- a/src/multi_period_dev.py
+++ b/src/multi_period_dev.py
@@ -1016,6 +1016,10 @@ def solve_multi_period_fpl(data, options):
         summary_of_actions = ""
         move_summary = {'chip': [], 'buy': [], 'sell': []}
         cumulative_xpts = 0
+
+        # collect statistics
+        statistics = {}
+
         for w in gameweeks:
             summary_of_actions += f"** GW {w}:\n"
             chip_decision = ("WC" if use_wc[w].get_value() > 0.5 else "") + ("FH" if use_fh[w].get_value() > 0.5 else "") + ("BB" if use_bb[w].get_value() > 0.5 else "") + ("TC" if use_tc_gw[w].get_value() > 0.5 else "")
@@ -1052,6 +1056,16 @@ def solve_multi_period_fpl(data, options):
             summary_of_actions += "Bench: \n\t" + ', '.join(bench_players['name'].tolist()) + "\n"
             summary_of_actions += "Lineup xPts: " + str(round(lineup_players['xp_cont'].sum(),2)) + "\n---\n\n"
             cumulative_xpts = cumulative_xpts + round(lineup_players['xp_cont'].sum(),2)
+
+            statistics[w] = {
+                'itb': in_the_bank[w].get_value(),
+                'ft': free_transfers[w].get_value(),
+                'pt': penalized_transfers[w].get_value(),
+                'nt': number_of_transfers[w].get_value(),
+                'xP': round(lineup_players['xp_cont'].sum(), 2),
+                'chip': chip_decision if chip_decision != "" else None
+            }
+
         print("Cumulative xPts: " + str(round(cumulative_xpts,2)) + "\n---\n\n")
 
         if options.get('delete_tmp', True):
@@ -1090,6 +1104,7 @@ def solve_multi_period_fpl(data, options):
             'picks': picks_df,
             'total_xp': total_xp,
             'summary': summary_of_actions,
+            'statistics': statistics,
             'buy': buy_decisions,
             'sell': sell_decisions,
             'chip': chip_decisions,

--- a/src/visualization.py
+++ b/src/visualization.py
@@ -3,7 +3,7 @@ import matplotlib.pyplot as plt
 import matplotlib.patches as patches
 
 
-def create_squad_timeline(current_squad, picks, filename):
+def create_squad_timeline(current_squad, statistics, picks, filename):
     df = pd.DataFrame(picks)
 
     bg_color = '#1a1a1a'
@@ -212,10 +212,24 @@ def create_squad_timeline(current_squad, picks, filename):
                         player_positions[week][in_p][0]
                     ], color=text_color, alpha=0.5, linewidth=1)
 
-        if week != base_week:
-            weekly_xp = gw_players['xP'].sum()
-            ax.text(gw_idx * gameweek_spacing, -1, f'{weekly_xp:.1f} xPts',
+        if week != base_week and week in statistics:
+            gw_statistics = statistics[week]
+
+            ax.text(gw_idx * gameweek_spacing, -1, f"{gw_statistics['xP']:.2f} xPts",
                     color=text_color, fontsize=10, ha='center')
+
+            ax.text(gw_idx * gameweek_spacing, -1.4, f"ITB: {gw_statistics['itb']:.1f}",
+                    color=text_color, fontsize=8, ha='center')
+
+            transfer_str = ''
+            for key in ["ft", "pt", "nt"]:
+                if key in gw_statistics:
+                    transfer_str += f'{key.upper()}: {gw_statistics[key]}  '
+
+            ax.text(gw_idx * gameweek_spacing, -1.75, transfer_str,
+                    color=text_color, fontsize=8, ha='center')
+
+
 
     total_width = (len(display_weeks) - 1) * gameweek_spacing + box_width
     ax.set_xlim(-5, total_width)


### PR DESCRIPTION
PR to extend the data displayed at the bottom of each gameweek to include ITB, FT, PT and NT in line with solver output.

![image](https://github.com/user-attachments/assets/a4e59bab-7c11-42bf-866e-5f4b5d47fe43)
