### PR TITLE
Add ability to solve with future price changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ You will need to follow steps below to install required platform and also optimi
     "banned_next_gw": [],
     "locked": [],
     "locked_next_gw": [],
+    "price_changes": [],
     "delete_tmp": true,
     "secs": 300,
     "use_cmd": false,
@@ -174,6 +175,7 @@ You will need to follow steps below to install required platform and also optimi
   - `banned_next_gw`: list of player IDs to be banned for the next gameweek. Alternatively, you can supply an `[ID, gameweek]` list as an element of the list to ban a player just for one specific gameweek. E.g. `[100, [200, 32]]` bans player with ID 100 for the next gameweek, and bans player with ID 200 for gameweek 32
   - `locked`: list of player IDs to always have during the horizon (e.g. `233` for Salah)
   - `locked_next_gw`: List of player IDs to force just for the next gameweek. See `banned_next_gw` for extended usage
+  - `price_changes`: Supply a list of `[ID, price_change]` pairs to solve as if a player's price has risen or dropped compared to the live price. E.g. `[[311, 1], [351, -1]]` will solve as if Alexander-Arnold's price is £0.1m higher, and Haaland's price is £0.1m lower than it is in reality.
   - `delete_tmp`: `true` or `false` whether to delete generated temporary files after solve
   - `secs`: time limit for the solve (in seconds)
   - `use_cmd`: whether to use `os.system` or `subprocess` for running solver, default is `false`

--- a/data/regular_settings.json
+++ b/data/regular_settings.json
@@ -19,6 +19,7 @@
     "banned_next_gw": [],
     "locked": [],
     "locked_next_gw": [],
+    "price_changes": [],
     "keep": [],
     "delete_tmp": true,
     "single_solve": true,

--- a/run/solve_regular.py
+++ b/run/solve_regular.py
@@ -7,7 +7,7 @@ import pandas as pd
 import argparse
 import random
 import string
-
+import requests
 
 def get_random_id(n):
     return ''.join(random.choice(string.ascii_letters + string.digits) for _ in range(n))
@@ -65,11 +65,26 @@ def solve_regular(runtime_options=None):
             if team_id is None:
                 print("You must supply your team_id in data/regular_settings.json")
                 exit(0)
-            my_data = generate_team_json(team_id)
+            my_data = generate_team_json(team_id, options)
         else:
             try:
                 with open('../data/team.json') as f:
                     my_data = json.load(f)
+                price_changes = options.get("price_changes", [])
+                if price_changes:
+                    my_squad_ids = [x["element"] for x in my_data["picks"]]
+                    with requests.Session() as s:
+                        r = s.get("https://fantasy.premierleague.com/api/bootstrap-static/").json()["elements"]
+                    current_prices = {x["id"]: x["now_cost"] for x in r if x["id"] in my_squad_ids}
+                    for pid, change in price_changes:
+                        if pid not in my_squad_ids:
+                            continue
+                        new_price = current_prices[pid] + change
+                        player = [x for x in my_data["picks"] if x["element"] == pid][0]
+                        if player["purchase_price"] >= new_price:
+                            player["selling_price"] = new_price
+                        else:
+                            player["selling_price"] = player["purchase_price"] + (new_price - player["purchase_price"]) // 2
             except FileNotFoundError:
                 print(
                     """You must either:

--- a/src/multi_period_dev.py
+++ b/src/multi_period_dev.py
@@ -87,7 +87,8 @@ def get_my_data(session, team_id):
     return d
 
 
-def generate_team_json(team_id):
+def generate_team_json(team_id, options):
+    price_changes = {pid: change for pid, change in options.get("price_changes", [])}
     BASE_URL = "https://fantasy.premierleague.com/api"
     with requests.Session() as session:
         static_url = f"{BASE_URL}/bootstrap-static/"
@@ -135,6 +136,8 @@ def generate_team_json(team_id):
     }
     for player_id, purchase_price in squad.items():
         now_cost = [x for x in static["elements"] if x["id"] == player_id][0]["now_cost"]
+        if player_id in price_changes:
+            now_cost += price_changes[player_id]
 
         diff = now_cost - purchase_price
         if diff > 0:
@@ -176,6 +179,13 @@ def calculate_fts(transfers, next_gw, fh, wc_gws):
 def prep_data(my_data, options):
     r = requests.get('https://fantasy.premierleague.com/api/bootstrap-static/')
     fpl_data = r.json()
+    valid_ids = [x["id"] for x in fpl_data["elements"]]
+
+    for pid, change in options.get("price_changes", []):
+        if pid not in valid_ids:
+            continue
+        player = [x for x in fpl_data["elements"] if x["id"] == pid][0]
+        player["now_cost"] += change
 
     gw = 0
     for e in fpl_data['events']:


### PR DESCRIPTION
Adds the option to solve with future price changes in mind. Changes the selling price for the user's team data, as well as purchase price for all players the user doesn't own. Should work for both ID and JSON methods of team input