### PR TITLE
Add binary simulation option

### DIFF
--- a/data/regular_settings.json
+++ b/data/regular_settings.json
@@ -77,5 +77,10 @@
     "team_id": null,
     "export_image": true,
     "solve_name": "regular",
-    "override_next_gw": null
+    "override_next_gw": null,
+    "binary_files": {
+      "fplreview_binary_1.csv": 0.6,
+      "fplreview_binary_2.csv": 0.3,
+      "fplreview_binary_3.csv": 0.1
+    }
 }

--- a/run/simulations.py
+++ b/run/simulations.py
@@ -5,6 +5,7 @@ import time
 from concurrent.futures import ProcessPoolExecutor
 import argparse
 from solve_regular import solve_regular
+import json
 
 def run_sensitivity(options=None):
 
@@ -17,34 +18,62 @@ def run_sensitivity(options=None):
     else:
         runs = options.get('count', 1)
         processes = options.get('processes', 1)
+    
+    use_binaries = options.get('use_binaries', 'n')
 
-    start = time.time()
+    # if use_binaries is set loop through binary_files dict in regular_settings and set number of sim run for each binary based on provided weights
+    if use_binaries.lower() == 'y':
+        print("Using binary files for simulations")
+        with open('../data/regular_settings.json') as f:
+            settings = json.load(f)
 
-    # for i in range(runs):
-    #     print('Run no: ' + str(i))
-    #     os.system('python solve_regular.py --randomized true')
+        for binary, weight in settings["binary_files"].items():
+            weighted_runs = round(weight * runs)    
 
-    all_jobs = [{'run_no': str(i+1), 'randomized': True} for i in range(runs)]
+            print(f"Running {weighted_runs} simulations for binary file {binary}")
 
-    with ProcessPoolExecutor(max_workers=processes) as executor:
-        results = list(executor.map(solve_regular, all_jobs))
+            start = time.time()
 
-    end = time.time()
+            all_jobs = [{'run_no': str(i+1), 'randomized': True, 'binary_file_name': binary.rstrip('.csv')} for i in range(weighted_runs)]
 
-    print()
-    print(f"Total time taken is {(end - start) / 60:.2f} minutes")
+            with ProcessPoolExecutor(max_workers=processes) as executor:
+                results = list(executor.map(solve_regular, all_jobs))
+
+            end = time.time()
+
+            print()
+            print(f"Total time taken is {(end - start) / 60:.2f} minutes")    
+    else:
+        start = time.time()
+
+        # for i in range(runs):
+        #     print('Run no: ' + str(i))
+        #     os.system('python solve_regular.py --randomized true')
+
+        all_jobs = [{'run_no': str(i+1), 'randomized': True} for i in range(runs)]
+
+        with ProcessPoolExecutor(max_workers=processes) as executor:
+            results = list(executor.map(solve_regular, all_jobs))
+
+        end = time.time()
+
+        print()
+        print(f"Total time taken is {(end - start) / 60:.2f} minutes")
 
 if __name__ == "__main__":
     try:
         parser = argparse.ArgumentParser(description="Run sensitivity analysis")
         parser.add_argument("--no", type=int, help="Number of runs")
         parser.add_argument("--parallel", type=int, help="Number of parallel runs")
+        parser.add_argument("--use_binaries", type=str, help="Do you want to use binaries? (y/n)")
         args = parser.parse_args()
         options = {}
         if args.no:
             options['count'] = args.no
         if args.parallel:
             options['processes'] = args.parallel
+        if args.use_binaries:
+            options['use_binaries'] = args.use_binaries
     except:
         options = None
 

--- a/run/solve_regular.py
+++ b/run/solve_regular.py
@@ -142,7 +142,10 @@ def solve_regular(runtime_options=None):
             os.mkdir("../data/results/")
 
         solve_name = options.get('solve_name', 'regular')
-        filename = f"{solve_name}_{stamp}_{run_id}_{iter}"
+        if options.get("binary_file_name"):
+            filename = f"{solve_name}_{options.get("binary_file_name")}_{stamp}_{run_id}_{iter}"
+        else:
+            filename = f"{solve_name}_{stamp}_{run_id}_{iter}"
         result['picks'].to_csv('../data/results/' + filename + '.csv')
 
         if options.get('export_image', 0) and not is_colab:

--- a/src/data_parser.py
+++ b/src/data_parser.py
@@ -7,7 +7,11 @@ import numpy as np
 
 def read_data(options, source, weights=None, discard_am=False):
     if source == 'review':
-        data = pd.read_csv(options.get('data_path', '../data/fplreview.csv'))
+        if options.get("binary_file_name"):
+            data_path = "../data/" + options.get("binary_file_name") + ".csv"
+        else:
+            data_path = options.get('data_path', '../data/fplreview.csv')
+        data = pd.read_csv(data_path)
         data['review_id'] = data['ID']
         
         if discard_am:


### PR DESCRIPTION
See discord message in #optimization https://discord.com/channels/911108350538829845/911274664171565096/1331843342371131434, sharing here just in case its actually helpful, please feel free to ignore :)

Allow users to provide a dict in regular_settings with binary EV files and associated weights. simulations.py will divide up the total simulations runs across the binary files based on the provided weights. For example if a user provides a dict with 2 files with 0.5 weight each it will divide 100 total sims evenly between both binaries and run 50 for each. It will also name the results files based on the binary file used (hence why it touches solve_regular.py).
