### PR TITLE
Fix(solver): Correct Free Hit budget constraint and FT hit logic

### DIFF
--- a/dev/solver.py
+++ b/dev/solver.py
@@ -483,9 +483,9 @@ def solve_multi_period_fpl(data, options):
     model.add_constraints((raw_gw_ft[w] >= 6 - m * (1 - ft_above_ub[w]) for w in gws), name="ft_above_ub_lb")
     model.add_constraints((raw_gw_ft[w] <= 5 + m * ft_above_ub[w] for w in gws), name="ft_above_ub_ub")
 
-    # ft_below_lb[w] == 1  <=>  raw_gw_ft[w] < 0
+    # ft_below_lb[w] == 1  <=>  raw_gw_ft[w] < 1
     model.add_constraints((raw_gw_ft[w] <= 0 + m * (1 - ft_below_lb[w]) for w in gws), name="ft_below_lb_ub")
-    model.add_constraints((raw_gw_ft[w] >= -1 - m * ft_below_lb[w] for w in gws), name="ft_below_lb_lb")
+    model.add_constraints((raw_gw_ft[w] >= 1 - m * ft_below_lb[w] for w in gws), name="ft_below_lb_lb")
 
     # FREE TRANSFER LOGIC
 

--- a/dev/solver.py
+++ b/dev/solver.py
@@ -460,7 +460,7 @@ def solve_multi_period_fpl(data, options):
     model.add_constraints(
         (
             so.expr_sum(fh_sell_price[p] * squad[p, w - 1] for p in players) + in_the_bank[w - 1]
-            >= so.expr_sum(fh_sell_price[p] * squad_fh[p, w] for p in players)
+            >= so.expr_sum(buy_price[p] * squad_fh[p, w] for p in players)
             for w in gws
         ),
         name="fh_budget",
@@ -484,8 +484,8 @@ def solve_multi_period_fpl(data, options):
     model.add_constraints((raw_gw_ft[w] <= 5 + m * ft_above_ub[w] for w in gws), name="ft_above_ub_ub")
 
     # ft_below_lb[w] == 1  <=>  raw_gw_ft[w] < 0
-    model.add_constraints((raw_gw_ft[w] <= -1 + m * (1 - ft_below_lb[w]) for w in gws), name="ft_below_lb_ub")
-    model.add_constraints((raw_gw_ft[w] >= 0 - m * ft_below_lb[w] for w in gws), name="ft_below_lb_lb")
+    model.add_constraints((raw_gw_ft[w] <= 0 + m * (1 - ft_below_lb[w]) for w in gws), name="ft_below_lb_ub")
+    model.add_constraints((raw_gw_ft[w] >= -1 - m * ft_below_lb[w] for w in gws), name="ft_below_lb_lb")
 
     # FREE TRANSFER LOGIC
 


### PR DESCRIPTION
Hi!

I am submitting this PR as part of the group working with Alexandre Le Saux (Master of Data Science at CentraleSupélec).

This PR addresses the two bugs you described regarding the solver constraints:

Free Hit Budget: Fixed the fh_budget constraint (line 463). It now correctly uses buy_price (instead of fh_sell_price) to calculate the cost of the new Free Hit squad, while keeping the budget calculation based on selling prices.

Free Transfer Logic: Fixed the ft_below_lb logic for hit scenarios (around line 487). I adjusted the boundary conditions so that raw_gw_ft < 1 triggers the hit logic. This ensures that taking a single hit (resulting in 0 rollover transfers) is correctly identified, granting 1 FT the following week.

Thank you for your time and the guidance on these issues!