### PR TITLE
Skip whitespace-only paths in load_config_files

### DIFF
--- a/tests/test_options_parsing.py
+++ b/tests/test_options_parsing.py
@@ -72,6 +72,14 @@ def test_semicolon_only_config_path():
     assert config == {}
 
 
+def test_whitespace_only_config_path(capsys):
+    """Test that whitespace-only config paths are skipped silently."""
+    config = load_config_files(" ; ")
+    captured = capsys.readouterr()
+    assert config == {}
+    assert captured.out == ""
+
+
 @pytest.fixture
 def mock_argv(monkeypatch):
     """Fixture to temporarily replace sys.argv"""

--- a/utils.py
+++ b/utils.py
@@ -60,7 +60,7 @@ def load_config_files(config_paths):
     paths = config_paths.split(";")
     for path in paths:
         stripped_path = path.strip()
-        if not path:
+        if not stripped_path:
             continue
         try:
             with open(stripped_path) as f:
@@ -115,10 +115,7 @@ def cached_request(url):
         data = response.json()
 
         # Update cache
-        cache[url] = {
-            "data": data,
-            "timestamp": current_time
-        }
+        cache[url] = {"data": data, "timestamp": current_time}
 
         # Save cache to file
         with open(CACHE_FILE, "w") as f:


### PR DESCRIPTION
`load_config_files` splits its semicolon-delimited argument and skips blank entries, but the guard tests the raw `path` value rather than the stripped value used everywhere below it. A segment containing only spaces is not an empty string, so the guard does not skip it. Execution falls through to `open("")`, which raises `FileNotFoundError`, and the handler prints a warning naming a file that was never requested:

```
>>> load_config_files(" ; ")
Warning: Configuration file  not found
Warning: Configuration file  not found
```

Note: The `cached_request` hunk is `ruff-format` output from the repo's pre-commit config, not a deliberate change.